### PR TITLE
chore(RHTAPATCH-1069): unit-tests for runAccessCheck

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -115,7 +115,6 @@ func getNamespacesWithAccess(
 		for _, verb := range []string{"create", "list", "watch", "delete"} {
 			for _, resource := range []string{"applications", "components"} {
 				allowed, err := runAccessCheck(
-					e,
 					authCl,
 					c.Request().Header["X-Email"][0],
 					ns.Name,
@@ -169,7 +168,6 @@ func getUserNamespaces(e *echo.Echo, nameReq labels.Requirement) ([]core.Namespa
 
 // check if a user can perform a specific verb on a specific resource in namespace
 func runAccessCheck(
-	e *echo.Echo,
 	authCl authorizationv1Client.AuthorizationV1Interface,
 	user string,
 	namespace string,


### PR DESCRIPTION
 Add unit-tests to `runAccessCheck`.
We decided to perform the tests using the same test suite
we are using for the functional tests, using testenv.
It is setting up a real environment for us, and we don't
have to deal with ugly fakes when using the k8s authorization.