### PR TITLE
DRAFT: Automatically provision personal namespace

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	k8sapi "k8s.io/api/core/v1"
@@ -261,7 +262,7 @@ var _ = BeforeSuite(func() {
 	k8sClient = utils.StartTestEnv(schema, testEnv)
 
 	serverProcess, serverCancelFunc = utils.CreateWorkspaceManagerServer("main.go", nil, "")
-	utils.WaitForWorkspaceManagerServerToServe()
+	utils.WaitForWorkspaceManagerServerToServe("http://localhost:5000/health")
 
 	user1 := "user1@konflux.dev"
 	user2 := "user2@konflux.dev"
@@ -275,6 +276,8 @@ var _ = BeforeSuite(func() {
 	createRoleBinding(k8sClient, "namespace-access-user-binding", "test-tenant", user1, "namespace-access")
 	createRoleBinding(k8sClient, "namespace-access-user-binding-2", "test-tenant", user2, "namespace-access")
 	createRoleBinding(k8sClient, "namespace-access-user-binding-3", "test-tenant-2", user2, "namespace-access-2")
+
+	time.Sleep(3 * time.Second)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/api/v1alpha1/usersignup_types.go
+++ b/pkg/api/v1alpha1/usersignup_types.go
@@ -3,6 +3,8 @@ package v1alpha1
 type SignupStatusReason = string
 
 var SignedUp SignupStatusReason = "SignedUp"
+var NotSignedUp SignupStatusReason = "NotSignedUp"
+var UnknownSignUpStatus SignupStatusReason = "Unknown"
 
 type SignupStatus struct {
 	Ready  bool               `json:"ready"`

--- a/pkg/handlers/signup/provisioner/handlers.go
+++ b/pkg/handlers/signup/provisioner/handlers.go
@@ -1,0 +1,164 @@
+package provisioner
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	core "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/konflux-ci/workspace-manager/pkg/api/v1alpha1"
+)
+
+const (
+	UserEmailAnnotation string = "konflux-ci.dev/requester-email"
+	UserIdAnnotation    string = "konflux-ci.dev/requester-user-id"
+)
+
+func normalizeEmail(email string) string {
+	ret := strings.Replace(email, "@", "-", -1)
+	ret = strings.Replace(ret, "+", "-", -1)
+	ret = strings.Replace(ret, ".", "-", -1)
+	ret = strings.ToLower(ret)
+	suffix := "-tenant"
+	if len(ret+suffix) > 63 {
+		return ret[:63-len(suffix)] + suffix
+	}
+
+	return ret + suffix
+
+}
+
+type NSProvisioner struct {
+	k8sClient client.Client
+}
+
+func NewNSProvisioner(k8sClient client.Client) *NSProvisioner {
+	return &NSProvisioner{
+		k8sClient: k8sClient,
+	}
+}
+
+func (nsp *NSProvisioner) CheckNSExistHandler(c echo.Context) error {
+	email := c.Request().Header["X-Email"][0]
+	c.Logger().Info("Checking if namespace exists for user ", email)
+	nsName := normalizeEmail(email)
+	c.Logger().Info("Normalized namespace name  ", nsName)
+
+	ns := &core.Namespace{}
+	err := nsp.k8sClient.Get(
+		c.Request().Context(),
+		client.ObjectKey{
+			Namespace: "",
+			Name:      nsName,
+		},
+		ns,
+	)
+
+	if err == nil {
+		return c.JSON(
+			http.StatusOK,
+			&v1alpha1.Signup{
+				SignupStatus: v1alpha1.SignupStatus{
+					Ready:  true,
+					Reason: v1alpha1.SignedUp,
+				},
+			},
+		)
+	}
+
+	if !errors.IsNotFound(err) {
+		return c.NoContent(http.StatusInternalServerError)
+	}
+
+	return c.JSON(
+		http.StatusNotFound,
+		&v1alpha1.Signup{
+			SignupStatus: v1alpha1.SignupStatus{
+				Ready:  false,
+				Reason: v1alpha1.NotSignedUp,
+			},
+		},
+	)
+
+}
+
+func (nsp *NSProvisioner) CreateNSHandler(c echo.Context) error {
+	// add X-User as a label/annotation
+	// add the original user email as label/annotation
+
+	email := c.Request().Header["X-Email"][0]
+	userId := c.Request().Header["X-User"][0]
+	c.Logger().Info("Creating namespace for user ", email)
+	nsName := normalizeEmail(email)
+	c.Logger().Info("Normalized namespace name  ", nsName)
+
+	ns := &core.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "",
+			Name:      nsName,
+			Labels: map[string]string{
+				"konflux.ci/type": "user",
+			},
+			Annotations: map[string]string{
+				UserEmailAnnotation: email,
+				UserIdAnnotation:    userId,
+			},
+		},
+	}
+
+	err := nsp.k8sClient.Create(c.Request().Context(), ns)
+
+	if errors.IsAlreadyExists(err) {
+		c.Logger().Infof("Namespace %s already exists", nsName)
+	} else if err != nil {
+		c.Logger().Errorf("Failed to create namespace %s, %s", nsName, err.Error())
+		return c.NoContent(http.StatusInternalServerError)
+	}
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: nsName,
+			Name:      "konflux-init-admin",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:     "User",
+				APIGroup: "rbac.authorization.k8s.io",
+				Name:     email,
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "konflux-admin-user-actions",
+		},
+	}
+
+	err = nsp.k8sClient.Create(c.Request().Context(), rb)
+	if errors.IsAlreadyExists(err) {
+		c.Logger().Warn("Role binding for the initial admin already exists.")
+	} else if err != nil {
+		c.Logger().Errorf(
+			"Failed to create admin role binding for user %s, %s",
+			email,
+			err.Error(),
+		)
+		return c.NoContent(http.StatusInternalServerError)
+	}
+
+	return c.String(
+		http.StatusOK,
+		fmt.Sprintf(
+			"namespace creation request for %s was completed successfully",
+			nsName,
+		),
+	)
+}

--- a/pkg/test/provision-test/provision_test.go
+++ b/pkg/test/provision-test/provision_test.go
@@ -2,7 +2,6 @@ package provision_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os/exec"
 	"testing"
@@ -11,6 +10,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/konflux-ci/workspace-manager/pkg/test/utils"
+	core "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -33,8 +34,12 @@ var _ = BeforeSuite(func() {
 	utilruntime.Must(clientgoscheme.AddToScheme(schema))
 	testEnv = &envtest.Environment{BinaryAssetsDirectory: "../../../bin/k8s/1.29.0-linux-amd64/"}
 	k8sClient = utils.StartTestEnv(schema, testEnv)
-	serverProcess, serverCancelFunc = utils.CreateWorkspaceManagerServer("../../../cmd/main.go", nil, "")
-	utils.WaitForWorkspaceManagerServerToServe()
+	serverProcess, serverCancelFunc = utils.CreateWorkspaceManagerServer(
+		"../../../cmd/main.go",
+		[]string{"WM_NS_PROVISION=true", "WM_HTTP_PORT=5001"},
+		"",
+	)
+	utils.WaitForWorkspaceManagerServerToServe("http://localhost:5001/health")
 })
 
 var _ = AfterSuite(func() {
@@ -42,27 +47,103 @@ var _ = AfterSuite(func() {
 	utils.StopEnvTest(testEnv)
 })
 
-var _ = Describe("simple test", func() {
-	endpoint := "http://localhost:5000/api/v1/signup"
+var _ = Describe("T", func() {
+	endpoint := "http://localhost:5001/api/v1/signup"
 	httpClient := &http.Client{}
+	headers := map[string][]string{
+		"X-Email": {"user1@konflux.dev"},
+		"X-User":  {"abc123"},
+	}
 
-	Context("simple test context", func() {
-		It("simple spec", func() {
-			request, err := http.NewRequest("GET", endpoint, nil)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(
-				func() (int, error) {
-					response, err := httpClient.Do(request)
-					if err != nil {
-						fmt.Println(err.Error())
-						return 0, err
-					}
-					return response.StatusCode, nil
-
-				},
-				10,
-				1,
-			).Should(Equal(http.StatusOK))
+	Context("checking if a user has a namespace", func() {
+		When("he/she doesn't have a namespace", func() {
+			It("should return StatusNotFound", func() {
+				request, err := http.NewRequest("GET", endpoint, nil)
+				request.Header = headers
+				Expect(err).NotTo(HaveOccurred())
+				response, err := httpClient.Do(request)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.StatusCode).Should(Equal(http.StatusNotFound))
+			})
 		})
 	})
+
+	Context("request to create a namespace for a user", func() {
+
+		var ns *core.Namespace
+		expectedNSName := "user1-konflux-dev-tenant"
+
+		// Run the same test twice to ensure the handler is idempotent
+		for i := 0; i < 2; i++ {
+			When("requesting a namespace multiple times", func() {
+				It("submits the request", func() {
+					request, err := http.NewRequest("POST", endpoint, nil)
+					request.Header = headers
+					Expect(err).NotTo(HaveOccurred())
+					response, err := httpClient.Do(request)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(response.StatusCode).Should(Equal(http.StatusOK))
+
+				})
+
+				It("creates the namespace", func() {
+					ns = &core.Namespace{}
+					err := k8sClient.Get(
+						context.TODO(),
+						client.ObjectKey{
+							Namespace: "",
+							Name:      expectedNSName,
+						},
+						ns,
+					)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("set the user's email in an annotation", func() {
+					Expect(ns.Annotations).Should(
+						HaveKeyWithValue(
+							"konflux-ci.dev/requester-email",
+							"user1@konflux.dev",
+						),
+					)
+				})
+
+				It("set the user's uuid in an annotation", func() {
+					Expect(ns.Annotations).Should(
+						HaveKeyWithValue(
+							"konflux-ci.dev/requester-user-id",
+							"abc123",
+						),
+					)
+				})
+
+				It("creates role binding for the user", func() {
+					rb := &rbacv1.RoleBinding{}
+					err := k8sClient.Get(
+						context.TODO(),
+						client.ObjectKey{
+							Namespace: expectedNSName,
+							Name:      "konflux-init-admin",
+						},
+						rb,
+					)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		}
+	})
+
+	Context("checking if a user has a namespace (after creating it)", func() {
+		When("he/she has a namespace", func() {
+			It("should return StatusOK", func() {
+				request, err := http.NewRequest("GET", endpoint, nil)
+				request.Header = headers
+				Expect(err).NotTo(HaveOccurred())
+				response, err := httpClient.Do(request)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(response.StatusCode).Should(Equal(http.StatusOK))
+			})
+		})
+	})
+
 })

--- a/pkg/test/utils/utils.go
+++ b/pkg/test/utils/utils.go
@@ -122,8 +122,7 @@ func CreateLogFile(dir string) *os.File {
 }
 
 // Wait for workspace-manager to start serving http requests
-func WaitForWorkspaceManagerServerToServe() {
-	endpoint := "http://localhost:5000/health"
+func WaitForWorkspaceManagerServerToServe(endpoint string) {
 	httpClient := &http.Client{}
 	request, err := http.NewRequest("GET", endpoint, nil)
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Extend Workspace manager to support automatic provisioning of personal namespaces.

The name of the namespace to create will be calculated from the user name, which is expected to be an email address.

The user that namespace is created for will get konflux-admin permissions on the namespace.

The implementation is idempotent.

This feature should be turned on using environment variables.

This change also adds an additional test suite. In order to run it at the same time with the existing test suite (the default of go test), allow to use different ports for workspace-manager.