### PR TITLE
Only read access is necessary to view

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -103,7 +103,7 @@ var getNamespacesWithAccess = func(
 	var allowedNs []core.Namespace
 	for _, ns := range allNamespaces {
 		notAllowed := false
-		for _, verb := range []string{"create", "list", "watch", "delete"} {
+		for _, verb := range []string{"list", "watch"} {
 			for _, resource := range []string{"applications", "components"} {
 				allowed, err := runAccessCheck(
 					authCl,


### PR DESCRIPTION
We have three roles: admin, maintainer, and contributor.

The contributor role grants you read-only verbs.

As this was previously coded, having contributor rights in a namespace would not be sufficient for it to show up in the workspace switcher.